### PR TITLE
TRAN-56: Added handling for multiple WSGI servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,5 @@ COPY requirements.txt /backend/
 RUN pip install -r requirements.txt
 RUN pip install tox
 COPY . /backend/
-RUN ls -la
 ENTRYPOINT ["/backend/docker-entrypoint.sh"]
 RUN ["chmod", "+x", "/backend/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DB_HOST=db # By default, it's pointing to db container run from docker-compose.
 DB_PORT=5432
 PORT=8000
 DJANGO_SERVER=django_wsgi
+ALLOWED_HOSTS=*
 ```
 Custom configuration can be added through 
 `.env` file. Following parameters are handled:
@@ -33,6 +34,7 @@ DEBUG=True # Determine if app should run in debug mode.
 SECRET_KEY # Secret key used by django app, by default value from transit.settings is used
 PORT=8000 # Django application port, if changed ports in docker-compose also have to be changed. 
 DJANGO_SERVER=django_wsgi # WSGI Server, environments other than local one should use `waitress` server instead
+ALLOWED_HOSTS=* # Passed to ALLOWED_HOSTS in djagno.settings, default * (all hosts) should not be used in production 
 ```
 
 #### 2. Build docker instance 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ DEBUG=True # Determine if app should run in debug mode.
 SECRET_KEY # Secret key used by django app, by default value from transit.settings is used
 PORT=8000 # Django application port, if changed ports in docker-compose also have to be changed. 
 DJANGO_SERVER=django_wsgi # WSGI Server, environments other than local one should use `waitress` server instead
-ALLOWED_HOSTS=* # Passed to ALLOWED_HOSTS in djagno.settings, default * (all hosts) should not be used in production 
+ALLOWED_HOSTS=* # Passed to ALLOWED_HOSTS in djagno.settings, default * (all hosts) should not be used in production, 
+# If more than one host is allowed, hosts should be separated with comma, e.g.: host1,host2,host3
 ```
 
 #### 2. Build docker instance 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ DB_PASSWORD=postgres
 DB_HOST=db # By default, it's pointing to db container run from docker-compose.
 DB_PORT=5432
 PORT=8000
+DJANGO_SERVER=django_wsgi
 ```
 Custom configuration can be added through 
 `.env` file. Following parameters are handled:
@@ -31,6 +32,7 @@ DB_HOST='127.0.0.1' # Database URL, dockerized instance uses 'db' service by def
 DEBUG=True # Determine if app should run in debug mode. 
 SECRET_KEY # Secret key used by django app, by default value from transit.settings is used
 PORT=8000 # Django application port, if changed ports in docker-compose also have to be changed. 
+DJANGO_SERVER=django_wsgi # WSGI Server, environments other than local one should use `waitress` server instead
 ```
 
 #### 2. Build docker instance 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - DB_PORT=${DB_PORT:-5432}
       - PORT=${PORT:-8000}
       - DJANGO_SERVER=${DJANGO_SERVER:-django_wsgi} # By default, use development server, actual server should use 'waitress'
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-*} # Warning: '*' should not be used in production
     depends_on:
       db:
         condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - DB_HOST=${DB_HOST:-db} # By default, it's pointing to db container
       - DB_PORT=${DB_PORT:-5432}
       - PORT=${PORT:-8000}
+      - DJANGO_SERVER=${DJANGO_SERVER:-django_wsgi} # By default, use development server, actual server should use 'waitress'
     depends_on:
       db:
         condition: service_started

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
 help() {
   echo """
   Commands
@@ -17,9 +20,23 @@ case "$1" in
   "start" )
     echo "Running migrations..."
     python manage.py migrate
-    echo "Django waitress server start..."
-    python server.py
-    #python manage.py runserver 0.0.0.0:${PORT:-8000}
+
+    if [[ -z "${DJANGO_SERVER}" ]]; then
+      # By default use waitress instance
+      D="django_wsgi"
+    else
+      # Note: this should be used only for development, it has hot reload but it's not optimized for multiple requests.
+      D="${DJANGO_SERVER,}"
+    fi
+    if [ "$D" = "waitress" ]; then
+      echo -e "${BLUE}Starting django waitress server.${NC}"
+      python server.py
+    else
+      echo -e "${BLUE}Running server with manage.py on port ${PORT}, this should be for local development only.${NC}"
+      echo -e "${BLUE}If you see this message on deployment server change value of environmental variable:
+      ${BLUE}DJANGO_SERVER=waitress.${NC}"
+      python manage.py runserver 0.0.0.0:${PORT:-8000}
+    fi
   ;;
   "manage" )
     ./manage.py "${@:2}"

--- a/transit/settings.py
+++ b/transit/settings.py
@@ -27,8 +27,8 @@ SECRET_KEY = os.getenv('SECRET_KEY', DEFAULT_SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 
-env_hosts = os.getenv('ALLOWED_HOSTS').split(',')
-ALLOWED_HOSTS = [*env_hosts]
+env_hosts = os.getenv('ALLOWED_HOSTS', '').split(',')
+ALLOWED_HOSTS = [host for host in env_hosts if host != '']
 
 
 # Application definition

--- a/transit/settings.py
+++ b/transit/settings.py
@@ -27,7 +27,8 @@ SECRET_KEY = os.getenv('SECRET_KEY', DEFAULT_SECRET_KEY)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 
-ALLOWED_HOSTS = []
+env_hosts = os.getenv('ALLOWED_HOSTS').split(',')
+ALLOWED_HOSTS = [*env_hosts]
 
 
 # Application definition

--- a/transit/settings.py
+++ b/transit/settings.py
@@ -138,6 +138,10 @@ REST_FRAMEWORK = {
 }
 
 SWAGGER_SETTINGS = {
+    'USE_SESSION_AUTH': DEBUG,  # Swagger doesn't need authenticated user in debug mode
+    # Outside debug - only admin has access to swagger definition
+    'LOGIN_URL': '/admin/login/',
+    'LOGOUT_URL': '/admin/logout/',
     'SECURITY_DEFINITIONS': {
         'Bearer': {
             'type': 'apiKey',


### PR DESCRIPTION
Changes: 
1. WSGI
If `DJANGO_SERVER` is undefined it's using django server, can be changed to `waitress` if actual deployment server is to be used. 
Additionaly swagger is exposed in DEBUG mode. 
2. ALLOWED_HOSTS 
Django [ALLOWD_HOSTS](https://docs.djangoproject.com/en/4.0/ref/settings/#allowed-hosts) can be set using environmental variables.
