### PR TITLE
Undefined media root was breaking docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - ./:/backend
       - ${PWD}/tox.ini:/backend/tox.ini
       - ${PWD}/server.py:/backend/server.py
-      - ./docker_data/media/${MEDIA_ROOT}:/backend/${MEDIA_ROOT}
+      - ./docker_data/media/${MEDIA_ROOT:-files}:/backend/${MEDIA_ROOT:-files}
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
Lack of MEDIA_ROOT was causing volume issues on default setup. Adding default path for MEDIA_ROOT should resolve it. 