### PR TITLE
TRAN-139: changed default pagination size from 20 to 10

### DIFF
--- a/transit/settings.py
+++ b/transit/settings.py
@@ -176,7 +176,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 20
+    'PAGE_SIZE': 10
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION
as a part of TICKET: https://sd-transit.atlassian.net/browse/TRAN-139

this change is for fixing server-side pagination on frontend side.