### PR TITLE
Fix customer week days replacement action

### DIFF
--- a/transit/rest_api/forms/customer/customer.py
+++ b/transit/rest_api/forms/customer/customer.py
@@ -91,7 +91,7 @@ class CustomerViewSet(BaseModelFormViewSet):
         customer = self.get_object()
         serializer = self._workhours_serializer(instance=customer, data=request.data)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            raise serializers.ValidationError(serializer.errors)
         return serializer
 
     def _valid_work_hours(self, serializer):

--- a/transit/rest_api/forms/customer/customer_week_days_utils.py
+++ b/transit/rest_api/forms/customer/customer_week_days_utils.py
@@ -20,7 +20,7 @@ class CustomerWeekDaysSerializerWrapper(serializers.Serializer):
     _service = CustomerWeekdaysService()
 
     week_days = serializers.ListField(
-        child=CustomerWeekDaysSerializerOptionalCustomer(), required=True, allow_empty=False
+        child=CustomerWeekDaysSerializerOptionalCustomer(), required=True, allow_empty=True
     )
 
     def update(self, instance, validated_data):

--- a/transit/tests/api_test/test_customer.py
+++ b/transit/tests/api_test/test_customer.py
@@ -93,6 +93,16 @@ class TestCustomerViewSet(ManualFormTestCaseMixin, TestCase):
         self.assertTrue(delivery_hour_1_created)
         self.assertTrue(delivery_hour_2_created)
 
+    def test_remove_working_hours(self):
+        token = self.USER_HELPER.get_access_token()
+        # Extend post request by additional week day data
+        self._POST_REQUEST_PAYLOAD['week_days'] = [{"day": 3, "closed": True}]
+        self.API_HELPER.make_post_request(
+            self._POST_REQUEST_PAYLOAD, token
+        )
+
+        self.API_HELPER.replace_working_hours({}, self.test_subject, token)
+        self.assertEqual(self.test_subject.week_days.count(), 0)
     def _build_week_days_payload(self):
         return {
             "week_days": [

--- a/transit/tests/api_test/test_customer.py
+++ b/transit/tests/api_test/test_customer.py
@@ -103,6 +103,7 @@ class TestCustomerViewSet(ManualFormTestCaseMixin, TestCase):
 
         self.API_HELPER.replace_working_hours({}, self.test_subject, token)
         self.assertEqual(self.test_subject.week_days.count(), 0)
+
     def _build_week_days_payload(self):
         return {
             "week_days": [


### PR DESCRIPTION
On validation failure response was not properly created and another unrelated exception raised in the process. 
Empty list was not allowed so removing delivery hours using endpoint was not possible. 